### PR TITLE
fix MC-265376 Kills by Goats are not counted in statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The server side part/fixes needs the mod to be installed on server side to work 
 - [MC-256638](https://bugs.mojang.com/browse/MC-256638) : _Riding a camel increments the 'Distance by Horse' statistic_ *
 - [MC-259687](https://bugs.mojang.com/browse/MC-259687) : _"Distance by Elytra" statistic is approximately doubled_
 - [MC-264274](https://bugs.mojang.com/browse/MC-264274) : _Lily pad and frogspawn do not increment "used" statistic when placed on water_
+- [MC-265376](https://bugs.mojang.com/browse/MC-265376) : _Kills by Goats are not counted in statistics_ (v1.1.0+)
 
 ```
 * the fix add a custom statistic and can be deactivated in the mod config file

--- a/src/main/java/be/elmital/fixmcstats/mixin/LivingEntityMixin.java
+++ b/src/main/java/be/elmital/fixmcstats/mixin/LivingEntityMixin.java
@@ -14,7 +14,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.stat.Stats;
 import net.minecraft.world.World;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/be/elmital/fixmcstats/mixin/LivingEntityMixin.java
+++ b/src/main/java/be/elmital/fixmcstats/mixin/LivingEntityMixin.java
@@ -5,19 +5,28 @@ import net.minecraft.entity.Attackable;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.damage.DamageType;
+import net.minecraft.entity.passive.GoatEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ElytraItem;
 import net.minecraft.item.ItemStack;
+import net.minecraft.registry.tag.TagKey;
 import net.minecraft.stat.Stats;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @SuppressWarnings("unused")
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin extends Entity implements Attackable {
+    @Shadow public abstract boolean isDead();
+
     public LivingEntityMixin(EntityType<?> type, World world) {
         super(type, world);
     }
@@ -29,5 +38,10 @@ public abstract class LivingEntityMixin extends Entity implements Attackable {
             if (((LivingEntity) (Object) this) instanceof PlayerEntity playerEntity)
                 playerEntity.incrementStat(Stats.BROKEN.getOrCreateStat(elytra.getItem()));
         }
+    }
+
+    @Redirect(method = "damage", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/damage/DamageSource;isIn(Lnet/minecraft/registry/tag/TagKey;)Z", ordinal = 5))
+    public boolean onDamage(DamageSource source, TagKey<DamageType> tag) {
+        return source.isIn(tag) && !(source.getAttacker() instanceof GoatEntity) && !isDead();
     }
 }


### PR DESCRIPTION
The damage source is created with a noAggro method call which means the damage type is in the NO_ANGER damage type tags. In the LivingEntity#damage method to set an attacker it checks if the damage type is not in the NO_ANGER damage type tag.
The attacker is never set in this case and so the "killed by" statistic is never incremented because to be incremented it s checks LivingEntity#getPrimeAdversary (returning the lastattacker) that returns a null entity in this scenario.

Closes #4 