### PR TITLE
feat MC-36696: experimental patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The server side part/fixes needs the mod to be installed on server side to work 
 
 ### Client side bug fixes :
 
+- [MC-36696](https://bugs.mojang.com/browse/MC-36696) : _Clicking on the statistics button on the menu screen advances the game by 1 tick_ (v1.3.2+)
 - [MC-80827](https://bugs.mojang.com/browse/MC-80827) : _Mob statistics have missing space between mob name and description_
 - [MC-139386](https://bugs.mojang.com/browse/MC-139386) : _Rare blocks and items highlighted in the Statistics page do not show rarity colours_
 - [MC-178516](https://bugs.mojang.com/browse/MC-178516) : _Statistics are not sorted correctly in languages using non-ASCII letters_** (v1.3.0+)

--- a/src/client/java/be/elmital/fixmcstats/mixin/client/StatsScreenMixin.java
+++ b/src/client/java/be/elmital/fixmcstats/mixin/client/StatsScreenMixin.java
@@ -1,0 +1,19 @@
+package be.elmital.fixmcstats.mixin.client;
+
+import be.elmital.fixmcstats.Config;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import net.minecraft.client.gui.screen.StatsScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(StatsScreen.class)
+public class StatsScreenMixin {
+
+    // Fix https://bugs.mojang.com/browse/MC-36696
+    @ModifyReturnValue(method = "shouldPause", at = @At(value = "RETURN"))
+    public boolean shouldPauseOverride(boolean original) {
+        if (!Config.instance().EXPERIMENTAL_STATS_SCREEN_TICK_FIX)
+            return original;
+        return true;
+    }
+}

--- a/src/client/resources/fix-mc-stats.client.mixins.json
+++ b/src/client/resources/fix-mc-stats.client.mixins.json
@@ -6,7 +6,8 @@
     "EntityStatsListWidgetEntryMixin",
     "GeneralStatsListWidgetMixin",
     "ItemComparatorMixin",
-    "ItemStatsListWidgetEntryMixin"
+    "ItemStatsListWidgetEntryMixin",
+    "StatsScreenMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/java/be/elmital/fixmcstats/Config.java
+++ b/src/main/java/be/elmital/fixmcstats/Config.java
@@ -19,6 +19,7 @@ public class Config {
     private final Properties properties = new Properties();
     public boolean USE_CAMEL_CUSTOM_STAT;
     public boolean USE_CRAWL_CUSTOM_STAT;
+    public boolean EXPERIMENTAL_STATS_SCREEN_TICK_FIX;
     static final String CONFIG = "FixMCStatsConfig";
 
     public static Config instance() {
@@ -38,7 +39,8 @@ public class Config {
         ELYTRA_FIX("elytra-experimental-fix", Boolean.TRUE.toString(), true),
         CAMEL_STAT("use-camel-riding-stat", Boolean.TRUE.toString()),
         CRAWL_STAT("use-crawling-stat", Boolean.TRUE.toString()),
-        ENDER_DRAGON_FLOWN_STAT_FIX("ender-dragon-flown-stat-experimental-fix", Boolean.TRUE.toString(), true);
+        ENDER_DRAGON_FLOWN_STAT_FIX("ender-dragon-flown-stat-experimental-fix", Boolean.TRUE.toString(), true),
+        EXPERIMENTAL_STATS_SCREEN_TICK_FIX("pause-tick-on-stats-screen-experimental-fix", Boolean.TRUE.toString());
 
         private final String key;
         private final String def;
@@ -109,6 +111,7 @@ public class Config {
         logger.info("Loading all configs");
         USE_CAMEL_CUSTOM_STAT = Boolean.parseBoolean(properties.getProperty(Configs.CAMEL_STAT.getKey(), Configs.CAMEL_STAT.getDefault()));
         USE_CRAWL_CUSTOM_STAT = Boolean.parseBoolean(properties.getProperty(Configs.CRAWL_STAT.getKey(), Configs.CRAWL_STAT.getDefault()));
+        EXPERIMENTAL_STATS_SCREEN_TICK_FIX = Boolean.parseBoolean(properties.getProperty(Configs.EXPERIMENTAL_STATS_SCREEN_TICK_FIX.getKey(), Configs.EXPERIMENTAL_STATS_SCREEN_TICK_FIX.getDefault()));
         return this;
     }
 


### PR DESCRIPTION
Patch to fix [MC-36696](https://bugs.mojang.com/browse/MC-36696).
It seems the overriding of the method in `StatsScreen$shouldPause` that return false while screen it's not fully init isn't needed.
The patch is marked experimental even if the changes shouldn't cause downside on other method calls from the code analysis.

Closes #15 