### PR TITLE
New patch for MC-277294 and MC-273933

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The server side part/fixes needs the mod to be installed on server side to work 
 - [MC-265376](https://bugs.mojang.com/browse/MC-265376) : _Kills by Goats are not counted in statistics_ (v1.1.0+)
 - [MC-268093](https://bugs.mojang.com/browse/MC-268093) : _Breaking a decorated pot with an arrow doesn't affect statistics_ (v1.1.0+)
 - [MC-273933](https://bugs.mojang.com/browse/MC-273933) : _"Times Used" statistic does not increase for armor when used on an armor stands_ (v2.0.0+)
+- [MC-277294](https://bugs.mojang.com/browse/MC-277294) : _Distance by mules and donkeys counts towards 'Distance by Horse' statistic_ (v2.0.0+)
 
 ```
 * the fix add a custom statistic and can be deactivated in the mod config file

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The server side part/fixes needs the mod to be installed on server side to work 
 - [MC-264274](https://bugs.mojang.com/browse/MC-264274) : _Lily pad and frogspawn do not increment "used" statistic when placed on water_
 - [MC-265376](https://bugs.mojang.com/browse/MC-265376) : _Kills by Goats are not counted in statistics_ (v1.1.0+)
 - [MC-268093](https://bugs.mojang.com/browse/MC-268093) : _Breaking a decorated pot with an arrow doesn't affect statistics_ (v1.1.0+)
+- [MC-273933](https://bugs.mojang.com/browse/MC-273933) : _"Times Used" statistic does not increase for armor when used on an armor stands_ (v2.0.0+)
 
 ```
 * the fix add a custom statistic and can be deactivated in the mod config file

--- a/src/main/java/be/elmital/fixmcstats/Configs.java
+++ b/src/main/java/be/elmital/fixmcstats/Configs.java
@@ -53,6 +53,7 @@ public class Configs {
     public static ConfigEntry KILLED_BY_GOAT_FIX = registerEntry(new ConfigEntry("killed-by-goat-fix", Boolean.TRUE.toString(), Patch.of(265376, ModEnvironment.SERVER), false, false));
     public static ConfigEntry ENDER_DRAGON_FLOWN_STAT_FIX = registerEntry(new ConfigEntry("ender-dragon-flown-stat-experimental-fix", Boolean.TRUE.toString(), Patch.of(267006, ModEnvironment.SERVER), false, true));
     public static ConfigEntry DECORATED_POT_BREAKING = registerEntry(new ConfigEntry("decorated-pot-breaking-fix", Boolean.TRUE.toString(), Patch.of(268093, ModEnvironment.SERVER), false, false));
+    public static ConfigEntry EQUIP_ARMOR_STAND_FIX = registerEntry(new ConfigEntry("equip-armor-stand-fix", Boolean.TRUE.toString(), Patch.of(273933, ModEnvironment.SERVER), false, false));
 
 
     public static class ConfigEntry {

--- a/src/main/java/be/elmital/fixmcstats/Configs.java
+++ b/src/main/java/be/elmital/fixmcstats/Configs.java
@@ -54,6 +54,8 @@ public class Configs {
     public static ConfigEntry ENDER_DRAGON_FLOWN_STAT_FIX = registerEntry(new ConfigEntry("ender-dragon-flown-stat-experimental-fix", Boolean.TRUE.toString(), Patch.of(267006, ModEnvironment.SERVER), false, true));
     public static ConfigEntry DECORATED_POT_BREAKING = registerEntry(new ConfigEntry("decorated-pot-breaking-fix", Boolean.TRUE.toString(), Patch.of(268093, ModEnvironment.SERVER), false, false));
     public static ConfigEntry EQUIP_ARMOR_STAND_FIX = registerEntry(new ConfigEntry("equip-armor-stand-fix", Boolean.TRUE.toString(), Patch.of(273933, ModEnvironment.SERVER), false, false));
+    public static ConfigEntry USE_DONKEY_STATS = registerEntry(new ConfigEntry("use-donkey-stat", Boolean.TRUE.toString(), Patch.of(277294, ModEnvironment.SERVER), false, false));
+    public static ConfigEntry USE_MULE_STATS = registerEntry(new ConfigEntry("use-mule-stat", Boolean.TRUE.toString(), Patch.of(277294, ModEnvironment.SERVER), false, false));
 
 
     public static class ConfigEntry {

--- a/src/main/java/be/elmital/fixmcstats/StatisticUtils.java
+++ b/src/main/java/be/elmital/fixmcstats/StatisticUtils.java
@@ -10,10 +10,13 @@ import org.slf4j.Logger;
 /* Used to register non-vanilla statistics and concern :
    - https://bugs.mojang.com/browse/MC-148457
    - https://bugs.mojang.com/browse/MC-256638
+   - https://bugs.mojang.com/browse/MC-277294
  */
 public class StatisticUtils {
     public static final CustomStatistic CAMEL_RIDING_STAT = new CustomStatistic("camel_one_cm", StatFormatter.DISTANCE);
     public static final CustomStatistic CRAWL_ONE_CM = new CustomStatistic("crawl_one_cm", StatFormatter.DISTANCE);
+    public static final CustomStatistic DONKEY_RIDING_STAT = new CustomStatistic("donkey_one_cm", StatFormatter.DISTANCE);
+    public static final CustomStatistic MULE_RIDING_STAT = new CustomStatistic("mule_one_cm", StatFormatter.DISTANCE);
 
     public static void register(CustomStatistic statistic) {
         Registry.register(Registries.CUSTOM_STAT, statistic.identifier(), statistic.identifier());
@@ -23,6 +26,10 @@ public class StatisticUtils {
     public static void registerAllCustomStats(Logger logger) {
         logger.info("Adding camel custom stat to the registry");
         StatisticUtils.register(StatisticUtils.CAMEL_RIDING_STAT);
+        logger.info("Adding donkey custom stat to the registry");
+        StatisticUtils.register(StatisticUtils.DONKEY_RIDING_STAT);
+        logger.info("Adding mule custom stat to the registry");
+        StatisticUtils.register(StatisticUtils.MULE_RIDING_STAT);
         logger.info("Adding crawling custom stat to the registry");
         StatisticUtils.register(StatisticUtils.CRAWL_ONE_CM);
     }

--- a/src/main/java/be/elmital/fixmcstats/mixin/ArmorStandEntityMixin.java
+++ b/src/main/java/be/elmital/fixmcstats/mixin/ArmorStandEntityMixin.java
@@ -1,0 +1,28 @@
+package be.elmital.fixmcstats.mixin;
+
+import be.elmital.fixmcstats.Configs;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.entity.decoration.ArmorStandEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.stat.Stats;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.Vec3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ArmorStandEntity.class)
+public class ArmorStandEntityMixin {
+
+    // https://bugs.mojang.com/browse/MC-273933
+    @Inject(method = "interactAt", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/decoration/ArmorStandEntity;equip(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/entity/EquipmentSlot;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/Hand;)Z"))
+    public void equipEntity(PlayerEntity player, Vec3d hitPos, Hand hand, CallbackInfoReturnable<ActionResult> cir, @Local ItemStack stack) {
+        if (Configs.EQUIP_ARMOR_STAND_FIX.isActive() && !stack.getItem().equals(Items.AIR)) {
+            player.incrementStat(Stats.USED.getOrCreateStat(stack.getItem()));
+        }
+    }
+}

--- a/src/main/java/be/elmital/fixmcstats/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/be/elmital/fixmcstats/mixin/ServerPlayerEntityMixin.java
@@ -7,6 +7,8 @@ import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.block.ScaffoldingBlock;
 import net.minecraft.entity.passive.CamelEntity;
+import net.minecraft.entity.passive.DonkeyEntity;
+import net.minecraft.entity.passive.MuleEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.packet.c2s.common.SyncedClientOptions;
 import net.minecraft.server.MinecraftServer;
@@ -25,9 +27,17 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity {
     }
 
     // Fix https://bugs.mojang.com/browse/MC-256638
+    // Fix https://bugs.mojang.com/browse/MC-277294
     @ModifyArg(method = "increaseRidingMotionStats", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;increaseStat(Lnet/minecraft/util/Identifier;I)V", ordinal = 3), index = 0)
     private Identifier modifyTargetStat(Identifier identifier) {
-        return getVehicle() instanceof CamelEntity && Configs.CAMEL_STAT.isActive() ? StatisticUtils.CAMEL_RIDING_STAT.identifier() : identifier;
+        if (getVehicle() instanceof CamelEntity && Configs.CAMEL_STAT.isActive())
+            return StatisticUtils.CAMEL_RIDING_STAT.identifier();
+        else if (getVehicle() instanceof DonkeyEntity && Configs.USE_DONKEY_STATS.isActive())
+            return StatisticUtils.DONKEY_RIDING_STAT.identifier();
+        else if (getVehicle() instanceof MuleEntity && Configs.USE_MULE_STATS.isActive())
+            return StatisticUtils.MULE_RIDING_STAT.identifier();
+        else
+            return identifier;
     }
 
     // Fix for https://bugs.mojang.com/browse/MC-148457

--- a/src/main/resources/assets/fix-mc-stats/lang/ar_sa.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/ar_sa.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "المسافة التي قطعت مع الجمل",
   "stat.fix-mc-stats.crawl_one_cm" : "مسافات الزحف",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "تعديل يهدف إلى إصلاح بعض المشكلات في إحصائيات Minecraft",
   "modmenu.summaryTranslation.fix-mc-stats" : "إصلاح عدد من الأخطاء في الإحصائيات."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/de_de.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/de_de.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Strecke auf Dromedar geritten",
   "stat.fix-mc-stats.crawl_one_cm" : "Strecke kroch",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod, die darauf abzielt, einige Probleme mit der Minecraft-Statistik zu beheben.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Behebung einiger Probleme mit den Minecraft-Statistiken."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/en_au.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/en_au.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Distance by Camel",
   "stat.fix-mc-stats.crawl_one_cm" : "Distance Crawled",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod that aims to fix some issues with the Minecraft statistics.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Fix some issues with the Minecraft statistics."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/en_ca.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/en_ca.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Distance by Camel",
   "stat.fix-mc-stats.crawl_one_cm" : "Distance Crawled",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod that aims to fix some issues with the Minecraft statistics.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Fix some issues with the Minecraft statistics."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/en_gb.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/en_gb.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Distance by Camel",
   "stat.fix-mc-stats.crawl_one_cm" : "Distance Crawled",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod that aims to fix some issues with the Minecraft statistics.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Fix some issues with the Minecraft statistics."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/en_us.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/en_us.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Distance by Camel",
   "stat.fix-mc-stats.crawl_one_cm" : "Distance Crawled",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod that aims to fix some issues with the Minecraft statistics.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Fix some issues with the Minecraft statistics."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/es_ar.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/es_ar.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Distancia sobre camello",
   "stat.fix-mc-stats.crawl_one_cm" : "Distancia arrastrada",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod diseñado para solucionar ciertos problemas con las estadísticas de Minecraft.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Corrige una serie de errores relacionados con las estadísticas."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/es_es.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/es_es.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Distancia sobre camello",
   "stat.fix-mc-stats.crawl_one_cm" : "Distancia arrastrada",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod diseñado para solucionar ciertos problemas con las estadísticas de Minecraft.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Corrige una serie de errores relacionados con las estadísticas."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/es_mx.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/es_mx.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Distancia sobre camello",
   "stat.fix-mc-stats.crawl_one_cm" : "Distancia arrastrada",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod diseñado para solucionar ciertos problemas con las estadísticas de Minecraft.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Corrige una serie de errores relacionados con las estadísticas."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/fr_ca.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/fr_ca.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Clique pour ouvrir le lien du rapport de bug du patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Distance à dromadaire",
   "stat.fix-mc-stats.crawl_one_cm" : "Distance parcourue en rampant",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance à dos d'âne",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance à mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod qui a pour but de corriger plusieurs bugs liés aux statistiques de MC.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Corrige plusieurs bugs liés aux statistiques."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/fr_fr.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/fr_fr.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Clique pour ouvrir le lien du rapport de bug du patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Distance à dromadaire",
   "stat.fix-mc-stats.crawl_one_cm" : "Distance parcourue en rampant",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance à dos d'âne",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance à mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod qui a pour but de corriger plusieurs bugs liés aux statistiques de MC.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Corrige plusieurs bugs liés aux statistiques."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/pl_pl.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/pl_pl.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Dystans przebyty na wielbłąd",
   "stat.fix-mc-stats.crawl_one_cm" : "Dystans przebyty przeczołgał",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod, który ma na celu naprawienie niektórych problemów ze statystykami Minecrafta.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Naprawiono kilka problemów ze statystykami Minecrafta."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/pt_br.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/pt_br.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Distância a camelo",
   "stat.fix-mc-stats.crawl_one_cm" : "Distância rastejar",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod que visa corrigir alguns problemas com as estatísticas do Minecraft.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Corrige uma série de erros com as estatísticas."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/pt_pt.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/pt_pt.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Distância a Dromedário",
   "stat.fix-mc-stats.crawl_one_cm" : "Distância rastejar",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Mod que visa corrigir alguns problemas com as estatísticas do Minecraft.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Corrige uma série de erros com as estatísticas."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/ru_ru.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/ru_ru.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "Преодолено верхом на Верблюд",
   "stat.fix-mc-stats.crawl_one_cm" : "Преодолено прополз",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "Мод, который призван исправить некоторые проблемы со статистикой Minecraft.",
   "modmenu.summaryTranslation.fix-mc-stats" : "Исправьте некоторые проблемы со статистикой Minecraft."
 }

--- a/src/main/resources/assets/fix-mc-stats/lang/zh_cn.json
+++ b/src/main/resources/assets/fix-mc-stats/lang/zh_cn.json
@@ -10,6 +10,8 @@
   "commands.fix-mc-stats.patch.link" : "Click to open the issue link for patch [%s]",
   "stat.fix-mc-stats.camel_one_cm" : "骑骆驼移动距离",
   "stat.fix-mc-stats.crawl_one_cm" : "爬行距离",
+  "stat.fix-mc-stats.donkey_one_cm" : "Distance by Donkey",
+  "stat.fix-mc-stats.mule_one_cm" : "Distance by Mule",
   "modmenu.descriptionTranslation.fix-mc-stats" : "旨在修复Minecraft统计中的一些问题的修改器",
   "modmenu.summaryTranslation.fix-mc-stats" : "修复Minecraft统计数据中的一些问题"
 }

--- a/src/main/resources/fix-mc-stats.mixins.json
+++ b/src/main/resources/fix-mc-stats.mixins.json
@@ -12,6 +12,7 @@
     "EntityMixin",
     "FlowerPotBlockMixin",
     "ForgingScreenHandlerMixin",
+    "ArmorStandEntityMixin",
     "LivingEntityMixin",
     "PlaceableOnWaterItemMixin",
     "PlayerEntityMixin",


### PR DESCRIPTION
- MC-273933 : 
The used statistic for armors and items isn't incremented when equipping an armor stand with one. The patch simply consist to call the increment method when it is

- MC-277294 : 
Like all entities extending #AbstractHorseEntity when a player ride one it will increment the Stats.HORSE_ONE_CM. The patch add custom statistics for each types of #AbstractDonkeyEntity and use them instead.

Closes #25 
Closes #26 