### PR TITLE
feat&fix: fix MC-301722 and camel stats wrongly incremented

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The server side part/fixes needs the mod to be installed on server side to work 
 - [MC-268093](https://bugs.mojang.com/browse/MC-268093) : _Breaking a decorated pot with an arrow doesn't affect statistics_ (v1.1.0+)
 - [MC-273933](https://bugs.mojang.com/browse/MC-273933) : _"Times Used" statistic does not increase for armor when used on an armor stands_ (v2.0.0+)
 - [MC-277294](https://bugs.mojang.com/browse/MC-277294) : _Distance by mules and donkeys counts towards 'Distance by Horse' statistic_* (v2.0.0+)
+- [MC-301722](https://bugs.mojang.com/browse/MC/issues/MC-301722) : _minecraft.custom:minecraft.happy_ghast_one_cm statistic increases while turning when not moving_ (v2.0.0+)
 
 ```
 * the fix add a custom statistic and can be deactivated in the mod config file

--- a/src/main/java/be/elmital/fixmcstats/Configs.java
+++ b/src/main/java/be/elmital/fixmcstats/Configs.java
@@ -56,6 +56,7 @@ public class Configs {
     public static ConfigEntry EQUIP_ARMOR_STAND_FIX = registerEntry(new ConfigEntry("equip-armor-stand-fix", Boolean.TRUE.toString(), Patch.of(273933, ModEnvironment.SERVER), false, false));
     public static ConfigEntry USE_DONKEY_STATS = registerEntry(new ConfigEntry("use-donkey-stat", Boolean.TRUE.toString(), Patch.of(277294, ModEnvironment.SERVER), false, false));
     public static ConfigEntry USE_MULE_STATS = registerEntry(new ConfigEntry("use-mule-stat", Boolean.TRUE.toString(), Patch.of(277294, ModEnvironment.SERVER), false, false));
+    public static ConfigEntry HAPPY_GHAST_RIDING_FIX = registerEntry(new ConfigEntry("happy-ghast-riding-fix", Boolean.TRUE.toString(), Patch.of(301722, ModEnvironment.SERVER), false, false));
 
 
     public static class ConfigEntry {

--- a/src/main/java/be/elmital/fixmcstats/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/be/elmital/fixmcstats/mixin/ServerPlayerEntityMixin.java
@@ -4,10 +4,13 @@ package be.elmital.fixmcstats.mixin;
 import be.elmital.fixmcstats.Configs;
 import be.elmital.fixmcstats.StatisticUtils;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalDoubleRef;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.block.ScaffoldingBlock;
 import net.minecraft.entity.passive.CamelEntity;
 import net.minecraft.entity.passive.DonkeyEntity;
+import net.minecraft.entity.passive.HappyGhastEntity;
 import net.minecraft.entity.passive.MuleEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.packet.c2s.common.SyncedClientOptions;
@@ -15,13 +18,24 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 @SuppressWarnings("unused")
 @Mixin(ServerPlayerEntity.class)
 public abstract class ServerPlayerEntityMixin extends PlayerEntity {
+    // Fix https://bugs.mojang.com/browse/MC/issues/MC-301722
+    @Unique
+    private @Nullable Vec3d lastVehiclePos = null;
+
     public ServerPlayerEntityMixin(MinecraftServer server, ServerWorld world, GameProfile profile, SyncedClientOptions clientOptions) {
         super(world, profile);
     }
@@ -38,6 +52,41 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity {
             return StatisticUtils.MULE_RIDING_STAT.identifier();
         else
             return identifier;
+    }
+
+    // Fix https://bugs.mojang.com/browse/MC/issues/MC-256638 this part of the fix prevents stats incrementation when player turn while not moving
+    // Fix https://bugs.mojang.com/browse/MC/issues/MC-301722
+    @Inject(method = "tickRiding", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;tickRiding()V"))
+    private void modifyBeforeSuperTickRiding(CallbackInfo ci, @Local(ordinal = 0) LocalDoubleRef x, @Local(ordinal = 1) LocalDoubleRef y, @Local(ordinal = 2) LocalDoubleRef z) {
+        if (getVehicle() != null) {
+            if (lastVehiclePos == null)
+                return;
+            if ((Configs.CAMEL_STAT.isActive() && getVehicle() instanceof CamelEntity) || (Configs.HAPPY_GHAST_RIDING_FIX.isActive() && getVehicle() instanceof HappyGhastEntity)) {
+                x.set(getVehicle().getX());
+                y.set(getVehicle().getY());
+                z.set(getVehicle().getZ());
+            }
+        }
+    }
+
+    // Fix https://bugs.mojang.com/browse/MC/issues/MC-256638 this part of the fix prevents stats incrementation when player turn while not moving
+    // Fix https://bugs.mojang.com/browse/MC/issues/MC-301722
+    @ModifyArgs(method = "tickRiding", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;increaseRidingMotionStats(DDD)V"))
+    private void modifyAfterSuperTickRiding(Args args) {
+        if (getVehicle() != null) {
+            if ((Configs.CAMEL_STAT.isActive() && getVehicle() instanceof CamelEntity) || (Configs.HAPPY_GHAST_RIDING_FIX.isActive() && getVehicle() instanceof HappyGhastEntity)) {
+                if (lastVehiclePos != null) {
+                    // Remove the player location added earlier in tickRiding method in the locals because we don't use the player location we need the vehicle location instead
+                    args.set(0, (double) args.get(0) - getX() + lastVehiclePos.getX());
+                    args.set(1, (double) args.get(1) - getY() + lastVehiclePos.getY());
+                    args.set(2, (double) args.get(2) - getZ() + lastVehiclePos.getZ());
+                }
+                lastVehiclePos = getVehicle().getPos();
+            }
+        } else {
+            // Player dismount so clear the last vehicle position
+            lastVehiclePos = null;
+        }
     }
 
     // Fix for https://bugs.mojang.com/browse/MC-148457


### PR DESCRIPTION
The calculation of the distance is based on the player's location but on certain mounts like Camel or Happy Ghast the player is not sited in the center of the mount and is therefore not aligned with it. When the player turns on itself on a mount the player location on x,z axis are modified due to this offset but the mount's position is not. The fix is to base the distance calculation on the mount's position rather than the player's. This bug doesn't occur for horses, mules and other because the player and the mount are aligned and therefore share the same location.


Closes #29 Fixes #30 