### PR TITLE
Fix: Client loading and server loading should be handled independently; otherwise, it may cause server startup failure.

### DIFF
--- a/fabric/src/main/java/be/elmital/fixmcstats/FixMcStats.java
+++ b/fabric/src/main/java/be/elmital/fixmcstats/FixMcStats.java
@@ -2,11 +2,8 @@ package be.elmital.fixmcstats;
 
 import be.elmital.fixmcstats.utils.StatisticUtils;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.fabric.api.command.v2.ArgumentTypeRegistry;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
-import net.minecraft.network.chat.Component;
 
 public class FixMcStats implements ModInitializer {
     @Override
@@ -21,14 +18,5 @@ public class FixMcStats implements ModInitializer {
         ArgumentTypeRegistry.registerArgumentType(BasicCommand.PATCH_ACTION_ARGUMENT.id, BasicCommand.PATCH_ACTION_ARGUMENT.clazz, BasicCommand.PATCH_ACTION_ARGUMENT.serializer);
         ArgumentTypeRegistry.registerArgumentType(BasicCommand.PATCH_ARGUMENT.id, BasicCommand.PATCH_ARGUMENT.clazz, BasicCommand.PATCH_ARGUMENT.serializer);
         BasicCommand.notifyArgumentRegisteringEnding();
-
-        ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) ->
-                BasicCommand.registerClientSide(dispatcher, new BasicCommand<>() {
-                    @Override
-                    public void sendClientFeedBack(FabricClientCommandSource clientCommandSource, Component text) {
-                        clientCommandSource.sendFeedback(text);
-                    }
-                })
-        );
     }
 }

--- a/fabric/src/main/java/be/elmital/fixmcstats/FixMcStatsClient.java
+++ b/fabric/src/main/java/be/elmital/fixmcstats/FixMcStatsClient.java
@@ -1,0 +1,24 @@
+package be.elmital.fixmcstats;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.network.chat.Component;
+
+@Environment(EnvType.CLIENT)
+public class FixMcStatsClient implements ClientModInitializer {
+
+    @Override
+    public void onInitializeClient() {
+        ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) ->
+                BasicCommand.registerClientSide(dispatcher, new BasicCommand<>() {
+                    @Override
+                    public void sendClientFeedBack(FabricClientCommandSource clientCommandSource, Component text) {
+                        clientCommandSource.sendFeedback(text);
+                    }
+                })
+        );
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -18,6 +18,9 @@
     "entrypoints": {
         "main": [
             "be.elmital.fixmcstats.FixMcStats"
+        ],
+        "client": [
+            "be.elmital.fixmcstats.FixMcStatsClient"
         ]
     },
     "mixins": [


### PR DESCRIPTION
Hmm~ Fix the following issue:
Cannot load class net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback in environment type SERVER