### PR TITLE
chore(MC-301722): make the patch deactivated by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The server side part/fixes needs the mod to be installed on server side to work 
 - [MC-273933](https://bugs.mojang.com/browse/MC-273933) : _"Times Used" statistic does not increase for armor when used on an armor stands_ (v2.0.0+)
 - [MC-276994](https://bugs.mojang.com/browse/MC-276994) : _The "used" statistic for music discs no longer increments when used on a jukebox_ (v2.2.0+)
 - [MC-277294](https://bugs.mojang.com/browse/MC-277294) : _Distance by mules and donkeys counts towards 'Distance by Horse' statistic_* (v2.0.0+)
-- [MC-301722](https://bugs.mojang.com/browse/MC/issues/MC-301722) : _minecraft.custom:minecraft.happy_ghast_one_cm statistic increases while turning when not moving_ (v2.0.0+)
+- [MC-301722](https://bugs.mojang.com/browse/MC/issues/MC-301722) : _minecraft.custom:minecraft.happy_ghast_one_cm statistic increases while turning when not moving_ (v2.0.0+) `Deactivated by default`
 - [MC-304642](https://bugs.mojang.com/browse/MC-304642) : _Being attacked from behind while holding up a shield increments "minecraft.used:minecraft.shield"_ (v2.2.0+)
 
 ```

--- a/common/src/main/java/be/elmital/fixmcstats/Configs.java
+++ b/common/src/main/java/be/elmital/fixmcstats/Configs.java
@@ -59,7 +59,7 @@ public class Configs {
     public static final ConfigEntry INCREMENT_USE_RECORDS = registerEntry(new ConfigEntry("increment-use-record-stat-fix", Boolean.TRUE.toString(), Patch.of(276994, ModEnvironment.SERVER), false, false));
     public static final ConfigEntry USE_DONKEY_STATS = registerEntry(new ConfigEntry("use-donkey-stat", Boolean.TRUE.toString(), Patch.of(277294, ModEnvironment.SERVER), false, false, true));
     public static final ConfigEntry USE_MULE_STATS = registerEntry(new ConfigEntry("use-mule-stat", Boolean.TRUE.toString(), Patch.of(277294, ModEnvironment.SERVER), false, false, true));
-    public static final ConfigEntry HAPPY_GHAST_RIDING_FIX = registerEntry(new ConfigEntry("happy-ghast-riding-fix", Boolean.TRUE.toString(), Patch.of(301722, ModEnvironment.SERVER), false, false));
+    public static final ConfigEntry HAPPY_GHAST_RIDING_FIX = registerEntry(new ConfigEntry("happy-ghast-riding-fix", Boolean.FALSE.toString(), Patch.of(301722, ModEnvironment.SERVER), false, false));
     public static final ConfigEntry SHIELD_USED_FIX = registerEntry(new ConfigEntry("shield-used-fix", Boolean.TRUE.toString(), Patch.of(304642, ModEnvironment.SERVER), false, false));
 
 


### PR DESCRIPTION
Mojang statused on the bug that it's working as intended.
The bug is caused by the fact that the player isn't aligned with the center of the ghast so when it turns on itself the player is "moving" and not just turning on itself like its mount.

I think this is still an issue; we want this statistic to track the mount's movements regardless of where the player is in the game world. Therefore the patch will be deactivated by default to match Mojang wills but will be maintained.