### PR TITLE
fix Neoforge crash on loadup in newest versions 26.2

### DIFF
--- a/common/src/main/java/be/elmital/fixmcstats/mixin/LivingEntityMixin.java
+++ b/common/src/main/java/be/elmital/fixmcstats/mixin/LivingEntityMixin.java
@@ -1,22 +1,16 @@
 package be.elmital.fixmcstats.mixin;
 
 import be.elmital.fixmcstats.Configs;
-import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.stats.Stats;
 import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Attackable;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.animal.goat.Goat;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.FireworkRocketEntity;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
+import net.minecraft.world.waypoints.WaypointTransmitter;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -26,28 +20,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @SuppressWarnings("unused")
 @Mixin(LivingEntity.class)
-public abstract class LivingEntityMixin extends Entity implements Attackable {
+public abstract class LivingEntityMixin implements Attackable, WaypointTransmitter {
     @Shadow public abstract boolean isDeadOrDying();
 
-    @Shadow public abstract ItemStack getItemBySlot(EquipmentSlot slot);
-
     @Shadow public abstract float getHealth();
-
-    public LivingEntityMixin(EntityType<?> type, Level world) {
-        super(type, world);
-    }
-
-    // Fix https://bugs.mojang.com/browse/MC-122656
-    @Inject(method = "updateFallFlying", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;hurtAndBreak(ILnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;)V", shift = At.Shift.AFTER))
-    public void incrementBreakingStat(CallbackInfo ci, @Local EquipmentSlot slot) {
-        if (!Configs.BREAKING_ELYTRA_AND_TRIDENT_FIX.isActive())
-            return;
-        ItemStack equipped = this.getItemBySlot(slot);
-        if (equipped.nextDamageWillBreak()) {
-            if (((LivingEntity) (Object) this) instanceof Player playerEntity)
-                playerEntity.awardStat(Stats.ITEM_BROKEN.get(equipped.getItem()));
-        }
-    }
 
     // Fix https://bugs.mojang.com/browse/MC-29519
     @Inject(method = "actuallyHurt", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;getCombatTracker()Lnet/minecraft/world/damagesource/CombatTracker;", shift = At.Shift.AFTER))

--- a/common/src/main/java/be/elmital/fixmcstats/mixinlogic/LivingEntity.java
+++ b/common/src/main/java/be/elmital/fixmcstats/mixinlogic/LivingEntity.java
@@ -1,0 +1,17 @@
+package be.elmital.fixmcstats.mixinlogic;
+
+import be.elmital.fixmcstats.Configs;
+import net.minecraft.stats.Stats;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+public class LivingEntity {
+    // Fix https://bugs.mojang.com/browse/MC-122656
+    public static void awardElytraBrokenStat(ItemStack stack, net.minecraft.world.entity.LivingEntity entity) {
+        if (!Configs.BREAKING_ELYTRA_AND_TRIDENT_FIX.isActive())
+            return;
+
+        if (stack.nextDamageWillBreak() && entity instanceof Player playerEntity)
+            playerEntity.awardStat(Stats.ITEM_BROKEN.get(stack.getItem()));
+    }
+}

--- a/fabric/src/main/java/be/elmital/fixmcstats/mixin/LivingEntityFabricMixin.java
+++ b/fabric/src/main/java/be/elmital/fixmcstats/mixin/LivingEntityFabricMixin.java
@@ -1,0 +1,19 @@
+package be.elmital.fixmcstats.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(LivingEntity.class)
+public class LivingEntityFabricMixin {
+    // Fix https://bugs.mojang.com/browse/MC-122656
+    @WrapOperation(method = "updateFallFlying", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;hurtAndBreak(ILnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;)V"))
+    public void incrementBreakingStat(ItemStack instance, int i, LivingEntity owner, EquipmentSlot slot, Operation<Void> original) {
+        original.call(instance, i, owner, slot);
+        be.elmital.fixmcstats.mixinlogic.LivingEntity.awardElytraBrokenStat(instance, (LivingEntity) (Object) this);
+    }
+}

--- a/fabric/src/main/resources/fix-mc-stats.fabric.mixins.json
+++ b/fabric/src/main/resources/fix-mc-stats.fabric.mixins.json
@@ -4,7 +4,8 @@
   "package": "be.elmital.fixmcstats.mixin",
   "compatibilityLevel": "JAVA_25",
   "mixins": [
-    "BlocksAttacksFabricMixin"
+    "BlocksAttacksFabricMixin",
+    "LivingEntityFabricMixin"
   ],
   "client": [],
   "server": [],

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,14 +20,14 @@ home_page=https://modrinth.com/mod/fixmcstats
 minecraft_version_range=[26.2, 26.3)
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=26.2-1
+neo_form_version=26.2-2
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.152.1+26.2
+fabric_version=0.155.2+26.2
 fabric_loader_version=0.19.3
 
 # NeoForge, see https://projects.neoforged.net/neoforged/neoforge for new versions
-neoforge_version=26.2.0.0-beta
+neoforge_version=26.2.0.32-beta
 neoforge_loader_version_range=[4,)
 
 # Gradle

--- a/neoforge/src/main/java/be/elmital/fixmcstats/mixin/LivingEntityNeoMixin.java
+++ b/neoforge/src/main/java/be/elmital/fixmcstats/mixin/LivingEntityNeoMixin.java
@@ -1,0 +1,19 @@
+package be.elmital.fixmcstats.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(LivingEntity.class)
+public class LivingEntityNeoMixin {
+    // Fix https://bugs.mojang.com/browse/MC-122656
+    @WrapOperation(method = "updateFallFlying", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;onGlideDamage(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;)V"))
+    public void incrementBreakingStat(ItemStack instance, LivingEntity livingEntity, EquipmentSlot equipmentSlot, Operation<Void> original) {
+        original.call(instance, livingEntity, equipmentSlot);
+        be.elmital.fixmcstats.mixinlogic.LivingEntity.awardElytraBrokenStat(instance, (LivingEntity) (Object) this);
+    }
+}

--- a/neoforge/src/main/resources/fix-mc-stats.neoforge.mixins.json
+++ b/neoforge/src/main/resources/fix-mc-stats.neoforge.mixins.json
@@ -3,7 +3,10 @@
   "minVersion": "0.8",
   "package": "be.elmital.fixmcstats.mixin",
   "compatibilityLevel": "JAVA_25",
-  "mixins": ["BlocksAttacksNeoMixin"],
+  "mixins": [
+    "BlocksAttacksNeoMixin",
+    "LivingEntityNeoMixin"
+  ],
   "client": [],
   "server": [],
   "injectors": {


### PR DESCRIPTION
Closes #52 

Neoforge remove the method called see comment  _by @elmital in [#52](https://github.com/elmital/FixMCStats/issues/52#issuecomment-5072490991)_

Fixing the bug by creating a separate mixin for Neoforge and Fabric. Fabric mixin target the vanilla method while Neoforge mixin target the internal Neoforge method used in replacement of the vanilla one.